### PR TITLE
Update tokio 2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,11 @@ rand = "0.7"
 serde = "1.0"
 serde_derive = "1.0"
 futures = "0.3"
-tokio = "0.2.0-alpha.6"
-
 clap = { version = "2.33", optional = true }
+
+[dependencies.tokio]
+version = "0.2"
+features = ["time", "rt-core", "macros"]
 
 [features]
 benchmark = ["clap"]

--- a/src/benchmark/bin.rs
+++ b/src/benchmark/bin.rs
@@ -159,7 +159,7 @@ async fn start_app() {
         .collect::<Vec<_>>()
         .await;
     info!("end await ");
-    statistics.display().await;
+    statistics.display();
     writer.close().await;
 }
 

--- a/src/benchmark/statistics.rs
+++ b/src/benchmark/statistics.rs
@@ -45,7 +45,7 @@ impl Statistics {
         self.pile = new_pile;
     }
 
-    pub async fn display(&mut self) {
+    pub fn display(&mut self) {
         println!("\n\n{:-^40}", "RESULTS");
         let total_count = self.pile.iter().fold(0, |acc, r| acc + r.count);
         Self::print("reports total:", total_count);

--- a/src/blob/core.rs
+++ b/src/blob/core.rs
@@ -188,7 +188,7 @@ impl Blob {
     }
 
     #[inline]
-    pub(crate) async fn read_all<'a>(&'a self, key: &'a [u8]) -> Entries<'a> {
+    pub(crate) fn read_all<'a>(&'a self, key: &'a [u8]) -> Entries<'a> {
         self.index.get_entry(key, self.file.clone())
     }
 
@@ -229,7 +229,7 @@ impl Blob {
     pub(crate) async fn get_all_metas(&self, key: &[u8]) -> Result<Vec<Meta>> {
         debug!("get_all_metas");
         let locations = self.index.get_all_meta_locations(key).await?;
-        debug!("gotten all meta locations");
+        trace!("gotten all meta locations");
         let mut metas = Vec::new();
         for location in locations {
             let meta_raw = self
@@ -239,7 +239,7 @@ impl Blob {
             let meta = Meta::from_raw(&meta_raw).map_err(Error::new)?;
             metas.push(meta);
         }
-        debug!("get all headers finished");
+        trace!("get all headers finished");
         Ok(metas)
     }
 }

--- a/src/blob/entry.rs
+++ b/src/blob/entry.rs
@@ -47,10 +47,10 @@ impl Entry {
     }
 
     pub(crate) fn new(meta: Meta, header: &RecordHeader, blob_file: File) -> Self {
-        let data_size = header.data_size().try_into().unwrap();
+        let data_size = header.data_size().try_into().expect("u64 to usize");
         let data_offset = header.data_offset();
         let blob_offset = header.blob_offset();
-        let full_size = header.full_size().try_into().unwrap();
+        let full_size = header.full_size().try_into().expect("u64 to usize");
         Self {
             meta,
             data_offset,

--- a/src/blob/file.rs
+++ b/src/blob/file.rs
@@ -11,7 +11,7 @@ pub(crate) struct File {
 #[inline]
 fn schedule_wake(waker: Waker) {
     tokio::spawn(async move {
-        delay(Instant::now() + Duration::from_millis(WOULDBLOCK_RETRY_INTERVAL_MS))
+        delay_for(Duration::from_millis(WOULDBLOCK_RETRY_INTERVAL_MS))
             .map(|_| waker.wake_by_ref())
             .await;
     });

--- a/src/blob/simple_index.rs
+++ b/src/blob/simple_index.rs
@@ -183,7 +183,7 @@ impl SimpleIndex {
             record_header_size,
             records_count: bunch.len(),
         };
-        let hs: usize = header.serialized_size()?.try_into().unwrap();
+        let hs: usize = header.serialized_size()?.try_into().expect("u64 to usize");
         let mut buf = Vec::with_capacity(hs + bunch.len() * record_header_size);
         serialize_into(&mut buf, &header)?;
         bunch

--- a/src/blob/simple_index.rs
+++ b/src/blob/simple_index.rs
@@ -91,9 +91,7 @@ impl SimpleIndex {
 
     pub(crate) fn get_entry<'a, 'b: 'a>(&'b self, key: &'a [u8], file: File) -> Entries<'a> {
         debug!("create iterator");
-        let entries = Entries::new(&self.inner, key, file);
-        trace!("entries: {:?}", entries);
-        entries
+        Entries::new(&self.inner, key, file)
     }
 
     #[inline]
@@ -113,15 +111,16 @@ impl SimpleIndex {
     }
 
     pub async fn load(mut file: &File) -> Result<Vec<RecordHeader>> {
-        debug!("seek to file start");
+        trace!("seek to file start");
         file.seek(SeekFrom::Start(0)).await?;
         let mut buf = Vec::new();
-        debug!("read to end index");
+        trace!("read to end index");
         file.read_to_end(&mut buf).await?;
         Ok(if buf.is_empty() {
             debug!("empty index file");
             Vec::new()
         } else {
+            trace!("deserialize bunch");
             Self::deserialize_bunch(&buf)?
         })
     }
@@ -201,14 +200,14 @@ impl SimpleIndex {
     }
 
     fn deserialize_bunch(buf: &[u8]) -> Result<Vec<RecordHeader>> {
-        debug!("deserialize header from buf: {}", buf.len());
+        trace!("deserialize header from buf: {}", buf.len());
         let header: Header = deserialize(buf)?;
         trace!("header deserialized: {:?}", header);
         let header_size: usize = header.serialized_size()?.try_into()?;
-        trace!("header serialized size: {}", header_size);
+        trace!("deserialize record header at: {}", header_size);
         (0..header.records_count).try_fold(Vec::new(), |mut record_headers, i| {
             let offset = header_size + i * header.record_header_size;
-            trace!("deserialize record header at: {}", offset);
+            trace!("at: {}", offset);
             deserialize(&buf[offset..])
                 .map(|rh| {
                     record_headers.push(rh);
@@ -218,7 +217,7 @@ impl SimpleIndex {
         })
     }
 
-    async fn check_result(res: Result<RecordHeader>) -> Result<bool> {
+    fn check_result(res: Result<RecordHeader>) -> Result<bool> {
         match res {
             Ok(_) => Ok(true),
             Err(ref e) if e.is(&ErrorKind::RecordNotFound) => Ok(false),
@@ -257,6 +256,7 @@ impl SimpleIndex {
         let mut buf = Vec::new();
         debug!("seek to file start");
         file.seek(SeekFrom::Start(0)).await.map_err(Error::new)?;
+        debug!("read to end index file");
         file.read_to_end(&mut buf).map_err(Error::new).await?;
         let bunch = Self::deserialize_bunch(&buf)?;
         self.inner = State::InMemory(bunch);
@@ -274,11 +274,11 @@ impl SimpleIndex {
 
 impl Index for SimpleIndex {
     fn contains_key(&self, key: &[u8]) -> ContainsKey {
-        ContainsKey(self.get(key).then(Self::check_result).boxed())
+        ContainsKey(self.get(key).map(Self::check_result).boxed())
     }
 
     fn push(&mut self, h: RecordHeader) -> Push {
-        trace!("push header: {:#?}", h);
+        trace!("push header: {:?}", h);
         let fut = match &mut self.inner {
             State::InMemory(bunch) => {
                 bunch.push(h);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ pub use storage::{Builder, Key, ReadAll, Storage};
 
 mod prelude {
     pub(crate) type PinBox<T> = Pin<Box<T>>;
-
     pub(crate) use super::*;
     pub(crate) use bincode::{deserialize, serialize, serialize_into, serialized_size};
     pub(crate) use blob::{self, Blob, File, Location};
@@ -98,8 +97,8 @@ mod prelude {
             Arc,
         },
         task::{Context, Poll, Waker},
-        time::{Duration, Instant},
+        time::Duration,
     };
-    pub(crate) use tokio::timer::{delay, Interval};
+    pub(crate) use tokio::time::{delay_for, interval};
     pub(crate) use {Key, Meta};
 }

--- a/src/storage/core.rs
+++ b/src/storage/core.rs
@@ -191,9 +191,9 @@ impl<K> Storage<K> {
         let blobs: &Vec<Blob> = &safe.blobs;
         debug!("closed blobs extracted");
         for blob in blobs {
-            debug!("look into next blob");
+            trace!("look into next blob");
             let meta = blob.get_all_metas(key.as_ref()).await.map_err(Error::new)?;
-            trace!("get all meta from blob {:#?} finished", blob);
+            trace!("get all meta from blob {:?} finished", blob);
             metas.extend(meta);
             debug!("extend finished");
         }
@@ -235,7 +235,7 @@ impl<K> Storage<K> {
     }
 
     /// Returns stream producing entries with matching key
-    pub async fn read_all<'a>(&'a self, key: &'a impl Key) -> ReadAll<'a, K> {
+    pub fn read_all<'a>(&'a self, key: &'a impl Key) -> ReadAll<'a, K> {
         ReadAll::new(self, key.as_ref())
     }
 

--- a/src/storage/observer.rs
+++ b/src/storage/observer.rs
@@ -15,8 +15,9 @@ impl Observer {
 
     pub(crate) async fn run(mut self) {
         debug!("update interval: {:?}", self.update_interval);
-        let mut interval = Interval::new(Instant::now(), self.update_interval);
-        while !self.inner.need_exit.load(Ordering::Relaxed) && interval.next().await.is_some() {
+        let mut interval = interval(self.update_interval);
+        while !self.inner.need_exit.load(Ordering::Relaxed) {
+            interval.tick().await;
             trace!("check active blob");
             if let Err(e) = self.try_update().await {
                 error!("{}", e);


### PR DESCRIPTION
### Benchmark:
2.1.0 stable version:
```
----------------RESULTS-----------------
     reports total:            1112
     reports collected:        1112
     test duration:           0.346
     written total, MB:     100.089
     rate, MB/s:            289.395
     rate, recs/s          3215.218
     avg latency:        298.982µs
```
2.0.0 alpha version:
```
----------------RESULTS-----------------
     reports total:            1112
     reports collected:        1112
     test duration:           0.450
     written total, MB:     100.089
     rate, MB/s:            222.470
     rate, recs/s          2471.670
     avg latency:        508.734µs
```