### PR TITLE
Add an option to ignore corrupted blobs

### DIFF
--- a/src/storage/builder.rs
+++ b/src/storage/builder.rs
@@ -122,6 +122,16 @@ impl Builder {
         self
     }
 
+    /// Ignores blobs with corrupted header for index file and continues work with normal
+    /// ones (also leaves error logs for bad blobs).
+    /// It's worth noticing that index file maybe corrupted likely in case of irregular
+    /// stop of the storage: either the disk disconnected or server crashed. In these cases blob
+    /// file is likely either corrupted, so there is no a try to restore indices from blob file.
+    pub fn ignore_corrupted(mut self) -> Self {
+        self.config.set_ignore_corrupted(true);
+        self
+    }
+
     /// Sets custom bloom filter config, if not set, use default values.
     #[must_use]
     pub fn set_filter_config(mut self, config: BloomConfig) -> Self {

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -9,6 +9,7 @@ pub(crate) struct Config {
     blob_file_name_prefix: Option<String>,
     update_interval_ms: u64,
     allow_duplicates: bool,
+    ignore_corrupted: bool,
     filter: Option<BloomConfig>,
     dump_sem: Arc<Semaphore>,
 }
@@ -43,6 +44,11 @@ impl Config {
     #[inline]
     pub const fn allow_duplicates(&self) -> bool {
         self.allow_duplicates
+    }
+
+    #[inline]
+    pub const fn ignore_corrupted(&self) -> bool {
+        self.ignore_corrupted
     }
 
     #[inline]
@@ -83,6 +89,10 @@ impl Config {
         self.allow_duplicates = allow_duplicates;
     }
 
+    pub fn set_ignore_corrupted(&mut self, ignore_corrupted: bool) {
+        self.ignore_corrupted = ignore_corrupted;
+    }
+
     pub fn set_filter(&mut self, filter: BloomConfig) {
         self.filter = Some(filter);
     }
@@ -107,6 +117,7 @@ impl Default for Config {
             blob_file_name_prefix: None,
             update_interval_ms: 100,
             allow_duplicates: false,
+            ignore_corrupted: false,
             filter: None,
             dump_sem: Arc::new(Semaphore::new(1)),
         }

--- a/src/storage/core.rs
+++ b/src/storage/core.rs
@@ -446,7 +446,6 @@ impl<K> Storage<K> {
         let mut blobs = Self::read_blobs(
             &files,
             self.inner.ioring.clone(),
-            self.filter_config(),
             disk_access_sem,
             &self.inner.config,
         )
@@ -481,7 +480,6 @@ impl<K> Storage<K> {
     async fn read_blobs(
         files: &[DirEntry],
         ioring: Option<Rio>,
-        filter_config: Option<BloomConfig>,
         disk_access_sem: Arc<Semaphore>,
         config: &Config,
     ) -> Result<Vec<Blob>> {
@@ -502,7 +500,7 @@ impl<K> Storage<K> {
             .map(|file| async {
                 let sem = disk_access_sem.clone();
                 let _sem = sem.acquire().await.expect("sem is closed");
-                Blob::from_file(file.clone(), ioring.clone(), filter_config.clone())
+                Blob::from_file(file.clone(), ioring.clone(), config.filter())
                     .await
                     .map_err(|e| (e, file))
             })


### PR DESCRIPTION
This will be helpful, if some other application wants to restart storage on the same disk after its disconnection (disk fault). This option let storage to start with normal blobs only instead of blocking if there are some (even 1) corrupted blobs (but probability of corrupted closed files after merging #85 PR will be reduced much)