### PR TITLE
Add check to avoid unneeded fsync operations

### DIFF
--- a/src/blob/core.rs
+++ b/src/blob/core.rs
@@ -71,11 +71,18 @@ impl Blob {
     }
 
     pub(crate) async fn dump(&mut self) -> Result<usize> {
-        self.file.fsyncdata().await?;
-        self.index
-            .dump()
-            .await
-            .with_context(|| "blob index dump failed")
+        if self.index.on_disk() {
+            Ok(0) // 0 bytes dumped
+        } else {
+            self.file
+                .fsyncdata()
+                .await
+                .with_context(|| "Blob file dump failed!")?;
+            self.index
+                .dump()
+                .await
+                .with_context(|| "Blob index file dump failed!")
+        }
     }
 
     pub(crate) async fn load_index(&mut self) -> Result<()> {

--- a/src/storage/core.rs
+++ b/src/storage/core.rs
@@ -746,8 +746,9 @@ impl Safe {
             // Notice: if dump of blob or indices fails, it's likely a problem with disk appeared, so
             // all descriptors of the storage become invalid and unusable
             // Possible solution: recreate instance of storage, when disk will be available
-            if let Err(e) = blobs.last_mut().unwrap().dump().await {
-                error!("Error dumping blob: {}", e);
+            let last_blob = blobs.last_mut().unwrap();
+            if let Err(e) = last_blob.dump().await {
+                error!("Error dumping blob ({}): {}", last_blob.name(), e);
             }
         }))
     }
@@ -759,7 +760,7 @@ impl Safe {
             for blob in write_blobs.iter_mut() {
                 let _ = sem.acquire().await;
                 if let Err(e) = blob.dump().await {
-                    error!("Error dumping blob: {}", e);
+                    error!("Error dumping blob ({}): {}", blob.name(), e);
                 }
             }
         });


### PR DESCRIPTION
Add check before performing dump steps AND make a bit more informative logs