### PR TITLE
Add key size check for blob from file

### DIFF
--- a/src/blob/core.rs
+++ b/src/blob/core.rs
@@ -416,7 +416,7 @@ struct RawRecords {
 }
 
 impl RawRecords {
-    async fn start(file: File, blob_header_size: u64, right_key_size: usize) -> Result<Self> {
+    async fn start(file: File, blob_header_size: u64, key_size: usize) -> Result<Self> {
         let current_offset = blob_header_size;
         debug!("blob raw records start, current offset: {}", current_offset);
         let size_of_usize = std::mem::size_of::<usize>();
@@ -437,7 +437,7 @@ impl RawRecords {
         Self::check_record_header_magic_byte(magic_byte)?;
         let key_len = bincode::deserialize::<usize>(&key_len_buf)
             .context("failed to deserialize index buf vec length")?;
-        if key_len != right_key_size {
+        if key_len != key_size {
             let msg = "blob key_sizeis not equal to pearl compile-time key size";
             return Err(Error::validation(msg).into());
         }

--- a/src/storage/core.rs
+++ b/src/storage/core.rs
@@ -456,7 +456,7 @@ impl<K: Key> Storage<K> {
             })?
             .boxed();
         let mut safe = self.inner.safe.write().await;
-        active_blob.load_index().await?;
+        active_blob.load_index(K::LEN).await?;
         for blob in &mut blobs {
             debug!("dump all blobs except active blob");
             blob.dump().await?;
@@ -492,7 +492,7 @@ impl<K: Key> Storage<K> {
             .map(|file| async {
                 let sem = disk_access_sem.clone();
                 let _sem = sem.acquire().await.expect("sem is closed");
-                Blob::from_file(file.clone(), ioring.clone(), config.filter())
+                Blob::from_file(file.clone(), ioring.clone(), config.filter(), K::LEN)
                     .await
                     .map_err(|e| (e, file))
             })


### PR DESCRIPTION
During index regeneration operations from blob file, first record of blob file is checked to have key of the same size, as compile-time key size for Pearl storage (if not equal - validation error).