### PR TITLE
B+ Tree generalization

### DIFF
--- a/src/blob/index/bptree/meta.rs
+++ b/src/blob/index/bptree/meta.rs
@@ -5,14 +5,21 @@ pub(super) struct TreeMeta {
     pub(super) root_offset: u64,
     pub(super) leaves_offset: u64,
     pub(super) tree_offset: u64,
+    pub(super) key_size: u64,
 }
 
 impl TreeMeta {
-    pub(super) fn new(root_offset: u64, leaves_offset: u64, tree_offset: u64) -> Self {
+    pub(super) fn new(
+        root_offset: u64,
+        leaves_offset: u64,
+        tree_offset: u64,
+        key_size: u64,
+    ) -> Self {
         Self {
             root_offset,
             leaves_offset,
             tree_offset,
+            key_size,
         }
     }
 

--- a/src/blob/index/bptree/mod.rs
+++ b/src/blob/index/bptree/mod.rs
@@ -7,7 +7,9 @@ mod serializer;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use self::core::BPTreeFileIndex;
+//pub(crate) use self::core::BPTreeFileIndex;
+// FIXME: restrict visibility
+pub(crate) use self::core::BPTreeFileIndexStruct;
 
 mod prelude {
     pub(super) use super::core::BLOCK_SIZE;

--- a/src/blob/index/bptree/serializer.rs
+++ b/src/blob/index/bptree/serializer.rs
@@ -53,7 +53,7 @@ pub(super) struct Serializer<
     headers_iter: It,
 }
 
-impl<'a, K: AsRef<[u8]> + 'a, V: Serialize + 'a, It: Iterator<Item = (K, &'a Vec<V>)> + Clone>
+impl<'a, K: AsRef<[u8]>, V: Serialize + 'a, It: Iterator<Item = (K, &'a Vec<V>)> + Clone>
     Serializer<'a, K, V, It>
 {
     pub(super) fn new(headers_iter: It) -> Self {
@@ -144,7 +144,12 @@ impl<'a, K: AsRef<[u8]>, V: Serialize + 'a, It: Iterator<Item = (K, &'a Vec<V>)>
         let tree_offset = self.leaves_offset + self.leaves_buf.len() as u64;
         let (root_offset, tree_buf) =
             Self::serialize_bptree(keys, self.leaves_offset, self.leaf_size as u64, tree_offset)?;
-        let metadata = TreeMeta::new(root_offset, self.leaves_offset, tree_offset);
+        let metadata = TreeMeta::new(
+            root_offset,
+            self.leaves_offset,
+            tree_offset,
+            (self.leaf_size - std::mem::size_of::<u64>()) as u64,
+        );
         let meta_buf = serialize(&metadata)?;
         Ok(TreeStage {
             headers_iter: self.headers_iter,

--- a/src/blob/index/bptree/tests.rs
+++ b/src/blob/index/bptree/tests.rs
@@ -13,10 +13,15 @@ async fn serialize_deserialize_file() {
             inmem.insert(key, vec![rh]);
         });
     let meta = vec![META_VALUE; META_SIZE];
-    let findex =
-        BPTreeFileIndex::from_records(&Path::new("/tmp/bptree_index.b"), None, &inmem, meta, true)
-            .await
-            .expect("Can't create file index");
+    let findex = BPTreeFileIndexStruct::<Vec<u8>, RecordHeader>::from_records(
+        &Path::new("/tmp/bptree_index.b"),
+        None,
+        &inmem,
+        meta,
+        true,
+    )
+    .await
+    .expect("Can't create file index");
     let (inmem_after, _size) = findex
         .get_records_headers()
         .await
@@ -37,7 +42,7 @@ async fn check_get_any() {
             inmem.insert(key, vec![rh]);
         });
     let meta = vec![META_VALUE; META_SIZE];
-    let findex = BPTreeFileIndex::from_records(
+    let findex = BPTreeFileIndexStruct::from_records(
         &Path::new("/tmp/any_bptree_index.b"),
         None,
         &inmem,
@@ -73,7 +78,7 @@ async fn check_get() {
             inmem.insert(key, recs);
         });
     let meta = vec![META_VALUE; META_SIZE];
-    let findex = BPTreeFileIndex::from_records(
+    let findex = BPTreeFileIndexStruct::from_records(
         &Path::new("/tmp/all_bptree_index.b"),
         None,
         &inmem,

--- a/src/blob/index/mod.rs
+++ b/src/blob/index/mod.rs
@@ -8,7 +8,8 @@ mod header;
 mod simple;
 mod tools;
 
-use bptree::BPTreeFileIndex;
+//use bptree::BPTreeFileIndex;
+use bptree::BPTreeFileIndexStruct;
 use header::IndexHeader;
 
 pub(crate) use self::core::{


### PR DESCRIPTION
We have in plans a move of our own b+ tree file implementation in separate crate, so first we need to make it self-sufficient and independent (generalize it, because if it will only work with our records it won't be useful enough). I highlight 3 steps:

- [x] Make first generalized version of b+ tree
- [ ] Fix weaknesses and bugs of first version
- [ ] Reorgonize module structure finally to get ready for the move (move all structs (such as `File`, `IndexHeader`) on which bptree depends closer to bptree module)

During solving the 1 step I encountered some difficulties, which means, that second step won't be instantaneous. 
Changes are significant AND I am not sure, that I will do it in right way from the first attempt, so to prevent reverts and weird manipulations, I decided to separate generalization in another PR and work on generalization in it.