### PR TITLE
Add range indices

### DIFF
--- a/src/blob/core.rs
+++ b/src/blob/core.rs
@@ -328,7 +328,11 @@ impl Blob {
 
     pub(crate) fn check_filters(&self, key: &[u8]) -> bool {
         trace!("check filters (range and bloom)");
-        self.index.check_filters_key(key)
+        if let FilterResult::NotContains = self.index.check_filters_key(key) {
+            false
+        } else {
+            true
+        }
     }
 
     pub(crate) async fn check_filters_non_blocking(&self, key: &[u8]) -> bool {

--- a/src/blob/core.rs
+++ b/src/blob/core.rs
@@ -215,10 +215,15 @@ impl Blob {
         Ok(())
     }
 
-    pub(crate) async fn read_any(&self, key: &[u8], meta: Option<&Meta>) -> Result<Vec<u8>> {
+    pub(crate) async fn read_any(
+        &self,
+        key: &[u8],
+        meta: Option<&Meta>,
+        check_filters: bool,
+    ) -> Result<Vec<u8>> {
         debug!("blob read any");
         let entry = self
-            .get_entry(key, meta)
+            .get_entry(key, meta, check_filters)
             .await?
             .ok_or_else(|| Error::from(ErrorKind::RecordNotFound))?;
         debug!("blob read any entry found");
@@ -247,10 +252,15 @@ impl Blob {
             .collect()
     }
 
-    async fn get_entry(&self, key: &[u8], meta: Option<&Meta>) -> Result<Option<Entry>> {
+    async fn get_entry(
+        &self,
+        key: &[u8],
+        meta: Option<&Meta>,
+        check_filters: bool,
+    ) -> Result<Option<Entry>> {
         debug!("blob get any entry {:?}, {:?}", key, meta);
-        if self.check_filters(key) == Some(false) {
-            debug!("blob core get any entry check bloom returned Some(false)");
+        if check_filters && !self.check_filters(key) {
+            debug!("Key was filtered out by filters");
             Ok(None)
         } else if let Some(meta) = meta {
             debug!("blob get any entry meta: {:?}", meta);
@@ -293,7 +303,7 @@ impl Blob {
 
     pub(crate) async fn contains(&self, key: &[u8], meta: Option<&Meta>) -> Result<bool> {
         debug!("blob contains");
-        let contains = self.get_entry(key, meta).await?.is_some();
+        let contains = self.get_entry(key, meta, true).await?.is_some();
         debug!("blob contains any: {}", contains);
         Ok(contains)
     }
@@ -316,17 +326,13 @@ impl Blob {
         self.name.id
     }
 
-    pub(crate) fn check_filters(&self, key: &[u8]) -> Option<bool> {
+    pub(crate) fn check_filters(&self, key: &[u8]) -> bool {
         trace!("check filters (range and bloom)");
         self.index.check_filters_key(key)
     }
 
-    pub(crate) async fn check_filters_async<R>(&self, key: &[u8], index: R) -> Option<R> {
-        if self.check_filters(key).unwrap_or(true) {
-            Some(index)
-        } else {
-            None
-        }
+    pub(crate) async fn check_filters_non_blocking(&self, key: &[u8]) -> bool {
+        self.check_filters(key)
     }
 
     pub(crate) fn index_memory(&self) -> usize {

--- a/src/blob/core.rs
+++ b/src/blob/core.rs
@@ -321,6 +321,14 @@ impl Blob {
         self.index.check_filters_key(key)
     }
 
+    pub(crate) async fn check_filters_async<R>(&self, key: &[u8], index: R) -> Option<R> {
+        if self.check_filters(key).unwrap_or(true) {
+            Some(index)
+        } else {
+            None
+        }
+    }
+
     pub(crate) fn index_memory(&self) -> usize {
         self.index.memory_used()
     }

--- a/src/blob/core.rs
+++ b/src/blob/core.rs
@@ -249,7 +249,7 @@ impl Blob {
 
     async fn get_entry(&self, key: &[u8], meta: Option<&Meta>) -> Result<Option<Entry>> {
         debug!("blob get any entry {:?}, {:?}", key, meta);
-        if self.check_bloom(key) == Some(false) {
+        if self.check_filters(key) == Some(false) {
             debug!("blob core get any entry check bloom returned Some(false)");
             Ok(None)
         } else if let Some(meta) = meta {
@@ -316,9 +316,9 @@ impl Blob {
         self.name.id
     }
 
-    pub(crate) fn check_bloom(&self, key: &[u8]) -> Option<bool> {
-        trace!("check bloom filter");
-        self.index.check_bloom_key(key)
+    pub(crate) fn check_filters(&self, key: &[u8]) -> Option<bool> {
+        trace!("check filters (range and bloom)");
+        self.index.check_filters_key(key)
     }
 
     pub(crate) fn index_memory(&self) -> usize {

--- a/src/blob/index/core.rs
+++ b/src/blob/index/core.rs
@@ -88,13 +88,13 @@ impl<FileIndex: FileIndexTrait> IndexStruct<FileIndex> {
         self.range_filter.clear();
     }
 
-    pub(crate) fn check_filters_key(&self, key: &[u8]) -> Option<bool> {
+    pub(crate) fn check_filters_key(&self, key: &[u8]) -> bool {
         if !self.range_filter.contains(key) {
-            Some(false)
+            false
         } else if self.params.bloom_is_on {
-            Some(self.bloom_filter.contains(key))
+            self.bloom_filter.contains(key)
         } else {
-            None
+            true
         }
     }
 

--- a/src/blob/index/core.rs
+++ b/src/blob/index/core.rs
@@ -1,4 +1,5 @@
 use super::prelude::*;
+use std::mem::size_of;
 
 pub(crate) type Index = IndexStruct<BPTreeFileIndex>;
 
@@ -6,14 +7,14 @@ pub(crate) const HEADER_VERSION: u8 = 1;
 
 #[derive(Debug)]
 struct IndexParams {
-    filter_is_on: bool,
+    bloom_is_on: bool,
     recreate_file: bool,
 }
 
 impl IndexParams {
-    fn new(filter_is_on: bool, recreate_file: bool) -> Self {
+    fn new(bloom_is_on: bool, recreate_file: bool) -> Self {
         Self {
-            filter_is_on,
+            bloom_is_on,
             recreate_file,
         }
     }
@@ -21,14 +22,14 @@ impl IndexParams {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexConfig {
-    pub filter: Option<BloomConfig>,
+    pub bloom_config: Option<BloomConfig>,
     pub recreate_index_file: bool,
 }
 
 impl Default for IndexConfig {
     fn default() -> Self {
         Self {
-            filter: None,
+            bloom_config: None,
             recreate_index_file: true,
         }
     }
@@ -37,7 +38,8 @@ impl Default for IndexConfig {
 #[derive(Debug)]
 pub(crate) struct IndexStruct<FileIndex: FileIndexTrait> {
     mem: Option<MemoryAttrs>,
-    filter: Bloom,
+    range_filter: RangeFilter,
+    bloom_filter: Bloom,
     params: IndexParams,
     inner: State<FileIndex>,
     name: FileName,
@@ -65,12 +67,13 @@ pub(crate) enum State<FileIndex: FileIndexTrait> {
 
 impl<FileIndex: FileIndexTrait> IndexStruct<FileIndex> {
     pub(crate) fn new(name: FileName, ioring: Option<Rio>, config: IndexConfig) -> Self {
-        let params = IndexParams::new(config.filter.is_some(), config.recreate_index_file);
-        let filter = config.filter.map(Bloom::new).unwrap_or_default();
+        let params = IndexParams::new(config.bloom_config.is_some(), config.recreate_index_file);
+        let filter = config.bloom_config.map(Bloom::new).unwrap_or_default();
         let mem = Some(Default::default());
         Self {
             params,
-            filter,
+            bloom_filter: filter,
+            range_filter: RangeFilter::new(),
             inner: State::InMemory(BTreeMap::new()),
             mem,
             name,
@@ -81,12 +84,15 @@ impl<FileIndex: FileIndexTrait> IndexStruct<FileIndex> {
     pub(crate) fn clear(&mut self) {
         self.inner = State::InMemory(BTreeMap::new());
         self.mem = Some(Default::default());
-        self.filter.clear();
+        self.bloom_filter.clear();
+        self.range_filter.clear();
     }
 
-    pub fn check_bloom_key(&self, key: &[u8]) -> Option<bool> {
-        if self.params.filter_is_on {
-            Some(self.filter.contains(key))
+    pub(crate) fn check_filters_key(&self, key: &[u8]) -> Option<bool> {
+        if !self.range_filter.contains(key) {
+            Some(false)
+        } else if self.params.bloom_is_on {
+            Some(self.bloom_filter.contains(key))
         } else {
             None
         }
@@ -103,14 +109,16 @@ impl<FileIndex: FileIndexTrait> IndexStruct<FileIndex> {
     ) -> Result<Self> {
         let findex = FileIndex::from_file(name.clone(), ioring.clone()).await?;
         findex.validate().with_context(|| "Header is corrupt")?;
-        let filter = Bloom::from_raw(&findex.read_meta().await?)?;
-        let params = IndexParams::new(config.filter.is_some(), config.recreate_index_file);
+        let meta_buf = findex.read_meta().await?;
+        let (bloom_filter, range_filter) = Self::deserialize_filters(&meta_buf)?;
+        let params = IndexParams::new(config.bloom_config.is_some(), config.recreate_index_file);
         trace!("index restored successfuly");
         let index = Self {
             inner: State::OnDisk(findex),
             mem: None,
             name,
-            filter,
+            bloom_filter,
+            range_filter,
             params,
             ioring,
         };
@@ -127,11 +135,12 @@ impl<FileIndex: FileIndexTrait> IndexStruct<FileIndex> {
                 return Ok(0);
             }
             debug!("blob index simple in memory headers {}", headers.len());
+            let meta_buf = self.serialize_filters()?;
             let findex = FileIndex::from_records(
                 &self.name.to_path(),
                 self.ioring.clone(),
                 headers,
-                self.filter.to_raw()?,
+                meta_buf,
                 self.params.recreate_file,
             )
             .await?;
@@ -144,11 +153,34 @@ impl<FileIndex: FileIndexTrait> IndexStruct<FileIndex> {
         }
     }
 
+    fn serialize_filters(&self) -> Result<Vec<u8>> {
+        let range_buf = self.range_filter.to_raw()?;
+        let range_buf_size = range_buf.len() as u64;
+        let bloom_buf = self.bloom_filter.to_raw()?;
+        let mut buf = Vec::with_capacity(size_of::<u64>() + range_buf.len() + bloom_buf.len());
+        buf.extend_from_slice(&serialize(&range_buf_size)?);
+        buf.extend_from_slice(&range_buf);
+        buf.extend_from_slice(&bloom_buf);
+        Ok(buf)
+    }
+
+    fn deserialize_filters(buf: &[u8]) -> Result<(Bloom, RangeFilter)> {
+        let (range_size_buf, rest_buf) = buf.split_at(size_of::<u64>());
+        let range_size = deserialize(&range_size_buf)?;
+        let (range_buf, bloom_buf) = rest_buf.split_at(range_size);
+        let bloom = Bloom::from_raw(bloom_buf)?;
+        let range = RangeFilter::from_raw(range_buf)?;
+        Ok((bloom, range))
+    }
+
     async fn load_in_memory(&mut self, findex: FileIndex) -> Result<()> {
         let (record_headers, records_count) = findex.get_records_headers().await?;
         self.mem = Some(compute_mem_attrs(&record_headers, records_count));
         self.inner = State::InMemory(record_headers);
-        self.filter = Bloom::from_raw(&findex.read_meta().await?)?;
+        let meta_buf = findex.read_meta().await?;
+        let (bloom_filter, range_filter) = Self::deserialize_filters(&meta_buf)?;
+        self.bloom_filter = bloom_filter;
+        self.range_filter = range_filter;
         Ok(())
     }
 
@@ -182,7 +214,8 @@ impl<FileIndex: FileIndexTrait + Sync + Send + Clone> IndexTrait for IndexStruct
         match &mut self.inner {
             State::InMemory(headers) => {
                 debug!("blob index simple push bloom filter add");
-                self.filter.add(h.key());
+                self.bloom_filter.add(h.key());
+                self.range_filter.add(h.key());
                 debug!("blob index simple push key: {:?}", h.key());
                 let mem = self
                     .mem

--- a/src/blob/index/mod.rs
+++ b/src/blob/index/mod.rs
@@ -16,7 +16,7 @@ use bptree::BPTreeFileIndex;
 use header::IndexHeader;
 
 pub(crate) use self::core::{
-    FileIndexTrait, InMemoryIndex, Index, IndexConfig, MemoryAttrs, HEADER_VERSION,
+    FileIndexTrait, FilterResult, InMemoryIndex, Index, IndexConfig, MemoryAttrs, HEADER_VERSION,
 };
 pub(crate) use super::prelude::*;
 pub(crate) use bloom::{Bloom, Config as BloomConfig};

--- a/src/blob/index/mod.rs
+++ b/src/blob/index/mod.rs
@@ -5,6 +5,7 @@ pub mod bloom;
 mod bptree;
 mod core;
 mod header;
+mod range;
 mod simple;
 mod tools;
 
@@ -19,6 +20,7 @@ pub(crate) use self::core::{
 };
 pub(crate) use super::prelude::*;
 pub(crate) use bloom::{Bloom, Config as BloomConfig};
+pub(crate) use range::RangeFilter;
 
 mod prelude {
     pub(crate) use super::*;

--- a/src/blob/index/range.rs
+++ b/src/blob/index/range.rs
@@ -22,16 +22,42 @@ impl RangeFilter {
             self.min = key_slice.to_vec();
             self.max = key_slice.to_vec();
             self.initialized = true;
-        } else if key_slice < &self.min {
+        } else if Self::lt(key_slice, &self.min) {
             self.min = key_slice.to_vec()
-        } else if key_slice > &self.max {
+        } else if Self::lt(&self.max, key_slice) {
             self.max = key_slice.to_vec()
+        }
+    }
+
+    pub(crate) fn lt(lv: &[u8], rv: &[u8]) -> bool {
+        if cfg!(target_endian = "big") {
+            lv < rv
+        } else {
+            // @FIXME: maybe there is a faster way to compare bytes of slices in reversed order?
+            if let CmpOrdering::Less = Iterator::cmp(lv.iter().rev(), rv.iter().rev()) {
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    pub(crate) fn le(lv: &[u8], rv: &[u8]) -> bool {
+        if cfg!(target_endian = "big") {
+            lv <= rv
+        } else {
+            // @FIXME: maybe there is a faster way to compare bytes of slices in reversed order?
+            if let CmpOrdering::Less = Iterator::cmp(rv.iter().rev(), lv.iter().rev()) {
+                false
+            } else {
+                true
+            }
         }
     }
 
     pub(crate) fn contains(&self, key: impl AsRef<[u8]>) -> bool {
         let key_slice = key.as_ref();
-        self.initialized && key_slice >= &self.min && key_slice <= &self.max
+        self.initialized && Self::le(&self.min, key_slice) && Self::le(key_slice, &self.max)
     }
 
     pub(crate) fn clear(&mut self) {

--- a/src/blob/index/range.rs
+++ b/src/blob/index/range.rs
@@ -1,0 +1,48 @@
+use super::prelude::*;
+
+/// It's worth notice, that current version may be inefficient in case of little endian keys
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub(crate) struct RangeFilter {
+    min: Vec<u8>,
+    max: Vec<u8>,
+    initialized: bool,
+}
+
+impl RangeFilter {
+    pub(crate) fn new() -> Self {
+        Self {
+            initialized: false,
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn add(&mut self, key: impl AsRef<[u8]>) {
+        let key_slice = key.as_ref();
+        if !self.initialized {
+            self.min = key_slice.to_vec();
+            self.max = key_slice.to_vec();
+            self.initialized = true;
+        } else if key_slice < &self.min {
+            self.min = key_slice.to_vec()
+        } else if key_slice > &self.max {
+            self.max = key_slice.to_vec()
+        }
+    }
+
+    pub(crate) fn contains(&self, key: impl AsRef<[u8]>) -> bool {
+        let key_slice = key.as_ref();
+        self.initialized && key_slice >= &self.min && key_slice <= &self.max
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.initialized = false;
+    }
+
+    pub(crate) fn from_raw(buf: &[u8]) -> Result<Self> {
+        bincode::deserialize(&buf).map_err(|e| e.into())
+    }
+
+    pub(crate) fn to_raw(&self) -> Result<Vec<u8>> {
+        bincode::serialize(&self).map_err(|e| e.into())
+    }
+}

--- a/src/blob/index/range.rs
+++ b/src/blob/index/range.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-/// It's worth notice, that current version may be inefficient in case of little endian keys
+/// NOTE: le and lt operations are written for big-endian format of keys
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub(crate) struct RangeFilter {
     min: Vec<u8>,
@@ -30,29 +30,15 @@ impl RangeFilter {
     }
 
     pub(crate) fn lt(lv: &[u8], rv: &[u8]) -> bool {
-        if cfg!(target_endian = "big") {
-            lv < rv
-        } else {
-            // @FIXME: maybe there is a faster way to compare bytes of slices in reversed order?
-            if let CmpOrdering::Less = Iterator::cmp(lv.iter().rev(), rv.iter().rev()) {
-                true
-            } else {
-                false
-            }
-        }
+        // NOTE: if it's keys are serialized in little-endian format you should use other
+        // comparison method: Iterator::cmp(lv.iter().rev(), rv.iter().rev())
+        lv < rv
     }
 
     pub(crate) fn le(lv: &[u8], rv: &[u8]) -> bool {
-        if cfg!(target_endian = "big") {
-            lv <= rv
-        } else {
-            // @FIXME: maybe there is a faster way to compare bytes of slices in reversed order?
-            if let CmpOrdering::Less = Iterator::cmp(rv.iter().rev(), lv.iter().rev()) {
-                false
-            } else {
-                true
-            }
-        }
+        // NOTE: if it's keys are serialized in little-endian format you should use other
+        // comparison method: Iterator::cmp(lv.iter().rev(), rv.iter().rev())
+        lv <= rv
     }
 
     pub(crate) fn contains(&self, key: impl AsRef<[u8]>) -> bool {

--- a/src/blob/mod.rs
+++ b/src/blob/mod.rs
@@ -12,6 +12,6 @@ pub(crate) use super::prelude::*;
 
 mod prelude {
     pub(crate) use super::*;
-    pub(crate) use index::Index;
+    pub(crate) use index::{FilterResult, Index};
     pub(crate) use std::sync::atomic::AtomicU64;
 }

--- a/src/storage/builder.rs
+++ b/src/storage/builder.rs
@@ -136,7 +136,7 @@ impl Builder {
     #[must_use]
     pub fn set_filter_config(mut self, config: BloomConfig) -> Self {
         let mut index_config = self.config.index();
-        index_config.filter = Some(config);
+        index_config.bloom_config = Some(config);
         self.config.set_index(index_config);
         self
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -464,11 +464,11 @@ async fn test_check_bloom_filter_single() {
         trace!("key: {}, pos: {:?}, negative: {:?}", i, pos_key, neg_key);
         let key = KeyTest::new(i);
         storage.write(&key, data.to_vec()).await.unwrap();
-        assert_eq!(storage.check_bloom(key).await, Some(true));
+        assert_eq!(storage.check_filters(key).await, Some(true));
         let data = b"other_random_data";
         storage.write(&pos_key, data.to_vec()).await.unwrap();
-        assert_eq!(storage.check_bloom(pos_key).await, Some(true));
-        assert_eq!(storage.check_bloom(neg_key).await, Some(false));
+        assert_eq!(storage.check_filters(pos_key).await, Some(true));
+        assert_eq!(storage.check_filters(neg_key).await, Some(false));
     }
     common::clean(storage, path).await.expect("clean failed");
     warn!("elapsed: {:.3}", now.elapsed().as_secs_f64());
@@ -487,10 +487,10 @@ async fn test_check_bloom_filter_multiple() {
         trace!("blobs count: {}", storage.blobs_count().await);
     }
     for i in 1..800 {
-        assert_eq!(storage.check_bloom(KeyTest::new(i)).await, Some(true));
+        assert_eq!(storage.check_filters(KeyTest::new(i)).await, Some(true));
     }
     for i in 800..1600 {
-        assert_eq!(storage.check_bloom(KeyTest::new(i)).await, Some(false));
+        assert_eq!(storage.check_filters(KeyTest::new(i)).await, Some(false));
     }
     common::clean(storage, path).await.expect("clean failed");
     warn!("elapsed: {:.3}", now.elapsed().as_secs_f64());
@@ -523,13 +523,13 @@ async fn test_check_bloom_filter_init_from_existing() {
     let storage = common::create_test_storage(&path, 100).await.unwrap();
     debug!("check check_bloom");
     for i in 1..base {
-        assert_eq!(storage.check_bloom(KeyTest::new(i)).await, Some(true));
+        assert_eq!(storage.check_filters(KeyTest::new(i)).await, Some(true));
     }
     info!("check certainly missed keys");
     let mut false_positive_counter = 0usize;
     for i in base..base * 2 {
         trace!("check key: {}", i);
-        if storage.check_bloom(KeyTest::new(i)).await == Some(true) {
+        if storage.check_filters(KeyTest::new(i)).await == Some(true) {
             false_positive_counter += 1;
         }
     }
@@ -571,13 +571,13 @@ async fn test_check_bloom_filter_generated() {
     debug!("check check_bloom");
     for i in 1..base {
         trace!("check key: {}", i);
-        assert_eq!(storage.check_bloom(KeyTest::new(i)).await, Some(true));
+        assert_eq!(storage.check_filters(KeyTest::new(i)).await, Some(true));
     }
     info!("check certainly missed keys");
     let mut false_positive_counter = 0usize;
     for i in base..base * 2 {
         trace!("check key: {}", i);
-        if storage.check_bloom(KeyTest::new(i)).await == Some(true) {
+        if storage.check_filters(KeyTest::new(i)).await == Some(true) {
             false_positive_counter += 1;
         }
     }


### PR DESCRIPTION
As I already mentioned in code, this version is inefficient for keys represented in little endian format, because vectors are compared from left to right (so from less grade to higher one) so, for example if we have u16 keys:
In worst case if range filter contains only numbers between 0 and 255 and these numbers (which are represented as [0, 0] and [255, 0]) there are only 255 numbers which will be filtered (511 = [255, 1], 767 = [255, 2], ... , 65535 = [255, 255]), but actually we can filter more than 65k (255, 256, 257, ... , 65535)

Default serializers (for example in [`Bob`](https://github.com/qoollo/bob) crate, which uses `Pearl`, [`bincode`](https://github.com/bincode-org/bincode) crate is used) for numbers try to work efficiently so they just copy numbers representation in memory to vectors and it [representation] depends on arch (little/big endian)

I have 3 solutions:
1. make it work only for little endian (because most of modern CPU uses little endian) and mention that somewhere (so for big endian systems it would be better to write custom serializer)
2. make it work for both little and big endian (I think there won't be performance and memory overheads)
3. make an optional field in config to choose, how to compare vector-keys (straight or reversed order; by default - reversed (check [1], why it is better))