### PR TITLE
Capability to perform update operation

### DIFF
--- a/src/blob/core.rs
+++ b/src/blob/core.rs
@@ -321,6 +321,14 @@ impl Blob {
         self.index.check_bloom_key(key)
     }
 
+    pub(crate) async fn check_bloom_async<'a, R>(&'a self, key: &[u8], index: R) -> Option<R> {
+        if self.check_bloom(key).unwrap_or(true) {
+            Some(index)
+        } else {
+            None
+        }
+    }
+
     pub(crate) fn index_memory(&self) -> usize {
         self.index.memory_used()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ mod prelude {
     pub(crate) use futures::{
         future,
         lock::Mutex,
-        stream::{futures_unordered::FuturesUnordered, TryStreamExt},
+        stream::{futures_unordered::FuturesUnordered, FuturesOrdered, TryStreamExt},
     };
     pub(crate) use record::{Header as RecordHeader, Record, RECORD_MAGIC_BYTE};
     pub(crate) use rio::Rio;

--- a/src/storage/core.rs
+++ b/src/storage/core.rs
@@ -303,7 +303,31 @@ impl<K: Key> Storage<K> {
         }
     }
 
-    async fn get_any_data(safe: &Safe, key: &[u8], meta: Option<&Meta>) -> Result<Vec<u8>> {
+    async fn get_data_last(safe: &Safe, key: &[u8], meta: Option<&Meta>) -> Result<Vec<u8>> {
+        let blobs = safe.blobs.read().await;
+        let blobs_stream: FuturesOrdered<_> = blobs
+            .iter()
+            .enumerate()
+            .map(|(i, blob)| blob.check_bloom_async(key, i))
+            .collect();
+        let possible_blobs: Vec<_> = blobs_stream.filter_map(|e| e).collect().await;
+        debug!(
+            "len of possible blobs: {} (start len: {})",
+            possible_blobs.len(),
+            blobs.len()
+        );
+        let stream: FuturesOrdered<_> = possible_blobs
+            .iter()
+            .rev()
+            .map(|i| blobs[*i].read_any(key, meta))
+            .collect();
+        debug!("read with optional meta {} closed blobs", stream.len());
+        let mut task = stream.skip_while(Result::is_err);
+        task.next().await.ok_or_else(Error::not_found)?
+    }
+
+    #[allow(dead_code)]
+    async fn get_data_any(safe: &Safe, key: &[u8], meta: Option<&Meta>) -> Result<Vec<u8>> {
         let blobs = safe.blobs.read().await;
         let stream: FuturesUnordered<_> =
             blobs.iter().map(|blob| blob.read_any(key, meta)).collect();
@@ -313,6 +337,10 @@ impl<K: Key> Storage<K> {
             .await
             .ok_or_else(Error::not_found)?
             .with_context(|| "no results in closed blobs")
+    }
+
+    async fn get_any_data(safe: &Safe, key: &[u8], meta: Option<&Meta>) -> Result<Vec<u8>> {
+        Self::get_data_last(safe, key, meta).await
     }
 
     /// Stop blob updater and release lock file


### PR DESCRIPTION
Update search strategy:
1. Bloom is checked as FuturesOrdered (to get indices of possibly useful blobs in ordered format, this doesn't affect performance because we need to wait for all bloom checks anyway)
2. Bloom-true blobs checked as FuturesOrdered in reversed order and the first (last === first in reversed order) is returned

This allows to retrieve the last record ==> define `update` operation as `write new` operation.

I checked this strategy and it doesn't affect performance much (but it depends on configuration (on my configuration it didn't affect at al), so I think it's better to leave both implementations)