### PR TITLE
New bits count calculations for bloom filter

### DIFF
--- a/src/blob/index/bloom.rs
+++ b/src/blob/index/bloom.rs
@@ -36,7 +36,7 @@ struct Save {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            elements: 1_000_000,
+            elements: 100_000,
             hashers_count: 2,
             max_buf_bits_count: 8_388_608, // 1Mb
             buf_increase_step: 8196,
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn check_inversed_formula() {
         use super::Config;
-        const EPSILON: f64 = 0.0001;
+        const EPSILON: f64 = 0.01;
 
         let config = Config::default();
 

--- a/src/blob/index/bloom.rs
+++ b/src/blob/index/bloom.rs
@@ -36,7 +36,7 @@ struct Save {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            elements: 100_000,
+            elements: 1_000_000,
             hashers_count: 2,
             max_buf_bits_count: 8_388_608, // 1Mb
             buf_increase_step: 8196,
@@ -45,32 +45,54 @@ impl Default for Config {
     }
 }
 
+fn m_from_fpr(fpr: f64, k: f64, n: f64) -> f64 {
+    -k * n / (1_f64 - fpr.powf(1_f64 / k)).ln()
+}
+
+fn bits_count_from_formula(config: &Config) -> usize {
+    let max_bit_count = config.max_buf_bits_count; // 1Mb
+    trace!("max bit count: {}", max_bit_count);
+    let k = config.hashers_count;
+    let n = config.elements as f64;
+    trace!("bloom filter for {} elements", n);
+    let mut bits_count = (n * k as f64 / 2_f64.ln()) as usize;
+    let fpr = config.preferred_false_positive_rate;
+    bits_count = bits_count.max(max_bit_count.min(m_from_fpr(fpr, k as f64, n) as usize));
+    bits_count
+}
+
+#[allow(dead_code)]
 fn false_positive_rate(k: f64, n: f64, m: f64) -> f64 {
     (1_f64 - 1_f64.exp().powf(-k * n / m)).powi(k as i32)
 }
 
+#[allow(dead_code)]
+fn bits_count_via_iterations(config: &Config) -> usize {
+    let max_bit_count = config.max_buf_bits_count; // 1Mb
+    trace!("max bit count: {}", max_bit_count);
+    let k = config.hashers_count;
+    let elements = config.elements as f64;
+    trace!("bloom filter for {} elements", elements);
+    let mut bits_count = (elements * k as f64 / 2_f64.ln()) as usize;
+    let bits_step = config.buf_increase_step;
+    let mut fpr = 1_f64;
+    while fpr > config.preferred_false_positive_rate {
+        fpr = false_positive_rate(k as f64, elements, bits_count as f64);
+        if bits_count >= max_bit_count {
+            break;
+        } else {
+            bits_count = max_bit_count.min(bits_step + bits_count);
+        }
+    }
+    bits_count
+}
+
 impl Bloom {
     pub fn new(config: Config) -> Self {
-        let elements = config.elements as f64;
-        trace!("bloom filter for {} elements", elements);
-        let max_bit_count = config.max_buf_bits_count; // 1Mb
-        trace!("max bit count: {}", max_bit_count);
-        let k = config.hashers_count;
-        let mut bits_count = (elements * k as f64 / 2_f64.ln()) as usize;
-        let bits_step = config.buf_increase_step;
-        let mut fpr = 1_f64;
-        while fpr > config.preferred_false_positive_rate {
-            fpr = false_positive_rate(k as f64, elements, bits_count as f64);
-            if bits_count >= max_bit_count {
-                trace!("false positive: {:.6}", fpr,);
-                break;
-            } else {
-                bits_count = max_bit_count.min(bits_step + bits_count);
-            }
-        }
+        let bits_count = bits_count_from_formula(&config);
         Self {
             inner: bitvec![0; bits_count],
-            hashers: Self::hashers(k),
+            hashers: Self::hashers(config.hashers_count),
             config,
         }
     }
@@ -141,5 +163,53 @@ impl Bloom {
                 hasher.finish() % len
             })
             .all(|i| *self.inner.get(i as usize).expect("unreachable"))
+    }
+}
+
+mod tests {
+    #[test]
+    fn check_inversed_formula() {
+        use super::Config;
+        const EPSILON: f64 = 0.0001;
+
+        let config = Config::default();
+
+        let inversed_formula_value = super::bits_count_from_formula(&config);
+        let iterations_method_value = super::bits_count_via_iterations(&config);
+
+        let min_value = iterations_method_value.min(inversed_formula_value) as f64;
+        let diff =
+            ((iterations_method_value as f64 - inversed_formula_value as f64) / min_value).abs();
+
+        assert!(
+            diff < EPSILON,
+            "description: {}\ninversed formula value: {}, iteration value: {}, diff: {}",
+            "bits_count relative diff is more than EPSILON",
+            inversed_formula_value,
+            iterations_method_value,
+            diff
+        );
+
+        let inversed_formula_fpr = super::false_positive_rate(
+            config.hashers_count as f64,
+            config.elements as f64,
+            inversed_formula_value as f64,
+        );
+        let iterations_method_fpr = super::false_positive_rate(
+            config.hashers_count as f64,
+            config.elements as f64,
+            iterations_method_value as f64,
+        );
+
+        let min_val = inversed_formula_fpr.min(iterations_method_fpr);
+        let diff = (inversed_formula_fpr - iterations_method_fpr).abs() / min_val;
+        assert!(
+            diff < EPSILON,
+            "description: {}\nfpr (inversed formula): {}, fpr (iterations method): {}, diff: {}",
+            "fpr relative diff is more than EPSILON",
+            inversed_formula_fpr,
+            iterations_method_fpr,
+            diff
+        );
     }
 }


### PR DESCRIPTION
New method calculates bits count values directly instead of iterations