### PR TITLE
should save corrupted blob on 'unexpected eof' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Pearl changelog
 
 
 #### Fixed
-
+- corrupted blob now should be saved in case of 'unexpected eof' error
 
 #### Updated
 

--- a/src/blob/core.rs
+++ b/src/blob/core.rs
@@ -529,12 +529,14 @@ impl RawRecords {
             .read_at(&mut buf, self.current_offset)
             .await
             .with_context(|| format!("read at call failed, size {}", self.current_offset))?;
-        let header = RecordHeader::from_raw(&buf).with_context(|| {
-            format!(
-                "header deserialization from raw failed, buf len: {}",
-                buf.len()
-            )
-        })?;
+        let header = RecordHeader::from_raw(&buf)
+            .map_err(|e| Error::from(ErrorKind::Bincode(e.to_string())))
+            .with_context(|| {
+                format!(
+                    "header deserialization from raw failed, buf len: {}",
+                    buf.len()
+                )
+            })?;
         self.current_offset += self.record_header_size;
         self.current_offset += header.meta_size();
         self.current_offset += header.data_size();

--- a/src/storage/core.rs
+++ b/src/storage/core.rs
@@ -3,7 +3,6 @@ use crate::error::ValidationErrorKind;
 use super::prelude::*;
 use futures::stream::FuturesOrdered;
 use tokio::fs::{create_dir, create_dir_all};
-use std::io::ErrorKind as IOErrorKind;
 
 const BLOB_FILE_EXTENSION: &str = "blob";
 

--- a/src/storage/core.rs
+++ b/src/storage/core.rs
@@ -653,9 +653,6 @@ where
                 },
                 _ => false,
             };
-        } else if let Some(bincode::ErrorKind::Io(error)) =
-            error.downcast_ref::<bincode::Error>().and_then(|b| Some(b.as_ref())) {
-            return error.kind() == std::io::ErrorKind::UnexpectedEof;
         }
         false
     }

--- a/src/storage/core.rs
+++ b/src/storage/core.rs
@@ -651,9 +651,11 @@ where
                 ErrorKind::Validation { kind, cause: _ } => {
                     !matches!(kind, ValidationErrorKind::BlobVersion)
                 },
-                ErrorKind::FileUnavailable(IOErrorKind::UnexpectedEof) => true,
                 _ => false,
             };
+        } else if let Some(bincode::ErrorKind::Io(error)) =
+            error.downcast_ref::<bincode::Error>().and_then(|b| Some(b.as_ref())) {
+            return error.kind() == std::io::ErrorKind::UnexpectedEof;
         }
         false
     }

--- a/src/storage/core.rs
+++ b/src/storage/core.rs
@@ -3,6 +3,7 @@ use crate::error::ValidationErrorKind;
 use super::prelude::*;
 use futures::stream::FuturesOrdered;
 use tokio::fs::{create_dir, create_dir_all};
+use std::io::ErrorKind as IOErrorKind;
 
 const BLOB_FILE_EXTENSION: &str = "blob";
 
@@ -649,7 +650,8 @@ where
                 ErrorKind::Bincode(_) => true,
                 ErrorKind::Validation { kind, cause: _ } => {
                     !matches!(kind, ValidationErrorKind::BlobVersion)
-                }
+                },
+                ErrorKind::FileUnavailable(IOErrorKind::UnexpectedEof) => true,
                 _ => false,
             };
         }


### PR DESCRIPTION
Corrupted blob now would be saved in case of 'unexpected eof' error