### PR TITLE
[272] Use `dep:<crate_name>` syntax in feature declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Pearl changelog
 
 
 #### Fixed
-
+- Use `dep:<crate_name>` syntax in feature declaration to avoid unnecessary feature flags (#272) 
 
 #### Updated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,8 @@ version = "1.21"
 features = ["fs", "io-util", "sync", "time", "rt", "macros", "rt-multi-thread"]
 
 [features]
-# default = ["benchmark"]
-benchmark = ["clap", "env_logger"]
-async-io-rio = ["rio"]
+benchmark = ["dep:clap", "dep:env_logger"]
+async-io-rio = ["dep:rio"]
 
 [lib]
 name = "pearl"


### PR DESCRIPTION
Closes #272 