### PR TITLE
300 fix build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Pearl changelog
 
 
 #### Fixed
-
+- Fixed build warnings (#300)
 
 #### Updated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ codegen-units = 1
 
 [dependencies]
 # Don't update without checking for backwards compatibility!!!
-ahash = "=0.7.6"
+# ahash = "=0.7.6"
+ahash = { git = 'https://github.com/tkaitchuck/aHash/', rev = 'e77cab8c1e15bfc9f54dfd28bd8820c2a7bb27c4' } 
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/src/blob/index/mod.rs
+++ b/src/blob/index/mod.rs
@@ -1,5 +1,4 @@
 use crate::{
-    prelude::*,
     storage::{BlobRecordTimestamp, ReadResult},
 };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 /// The error type for `Storage` operations.
-#[derive(Debug, Error)]
+#[derive(Debug, ThisError)]
 pub struct Error {
     kind: Kind,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ mod prelude {
             Arc,
         },
     };
-    pub(crate) use thiserror::Error;
+    pub(crate) use thiserror::Error as ThisError;
     pub(crate) use tokio::{
         fs::{read_dir, DirEntry},
         sync::{RwLock, Semaphore},

--- a/src/tools/blob_writer.rs
+++ b/src/tools/blob_writer.rs
@@ -67,7 +67,7 @@ impl BlobWriter {
         let mut reader = BlobReader::from_file(file)?;
         let header = reader.read_header()?;
         if header != *written_header {
-            return Err(Error::blob_header_validation_error(
+            return Err(ToolsError::blob_header_validation_error(
                 "validation of written blob header failed",
             )
             .into());
@@ -97,7 +97,7 @@ impl BlobWriter {
         for record in cache.iter() {
             let written_record = reader.read_single_record()?;
             if record != &written_record {
-                return Err(Error::record_validation_error(
+                return Err(ToolsError::record_validation_error(
                     "Written and cached records is not equal",
                 )
                 .into());

--- a/src/tools/error.rs
+++ b/src/tools/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 /// Error type
 #[derive(Debug, Error)]
-pub enum Error {
+pub enum ToolsError {
     /// Failed to validate record header
     #[error("record header validation error: {0}")]
     RecordHeaderValidation(String),
@@ -30,7 +30,7 @@ pub enum Error {
     UnsupportedKeySize(u16),
 }
 
-impl Error {
+impl ToolsError {
     pub(crate) fn record_header_validation_error(message: impl Into<String>) -> Self {
         Self::RecordHeaderValidation(message.into())
     }

--- a/src/tools/migration.rs
+++ b/src/tools/migration.rs
@@ -7,7 +7,7 @@ impl Record {
         match (source, target) {
             (source, target) if source >= target => Ok(self),
             (0, 1) => self.mirgate_v0_to_v1(),
-            (source, target) => Err(Error::unsupported_migration(source, target).into()),
+            (source, target) => Err(ToolsError::unsupported_migration(source, target).into()),
         }
     }
 
@@ -40,7 +40,7 @@ impl BlobHeader {
         match (source_version, target_version) {
             (source, target) if source >= target => Ok(self),
             (0, 1) => self.mirgate_v0_to_v1(),
-            (source, target) => Err(Error::unsupported_migration(source, target).into()),
+            (source, target) => Err(ToolsError::unsupported_migration(source, target).into()),
         }
     }
 

--- a/src/tools/utils.rs
+++ b/src/tools/utils.rs
@@ -144,7 +144,7 @@ where
             let res = index.get_records_headers(index.blob_size()).await?;
             AnyResult::<_>::Ok(res.0)
         }
-        _ => return Err(Error::index_header_validation_error("unsupported header version").into()),
+        _ => return Err(ToolsError::index_header_validation_error("unsupported header version").into()),
     }?;
     let headers = headers
         .into_iter()
@@ -163,7 +163,7 @@ pub async fn read_index(path: &Path) -> AnyResult<BTreeMap<Vec<u8>, Vec<record::
         32 => index_from_file::<ArrayKey<32>>(&header, path).await,
         64 => index_from_file::<ArrayKey<64>>(&header, path).await,
         128 => index_from_file::<ArrayKey<128>>(&header, path).await,
-        size => return Err(Error::unsupported_key_size(size).into()),
+        size => return Err(ToolsError::unsupported_key_size(size).into()),
     }?;
     for (_, headers) in headers.iter() {
         for header in headers {

--- a/src/tools/validation.rs
+++ b/src/tools/validation.rs
@@ -28,7 +28,7 @@ where
         header.blob_size()
     };
     let headers = if header.version() < HEADER_VERSION {
-        return Err(Error::index_header_validation_error(format!(
+        return Err(ToolsError::index_header_validation_error(format!(
             "Index version is outdated. Passed version: {}, latest version: {}",
             header.version(),
             HEADER_VERSION
@@ -43,7 +43,7 @@ where
             AnyResult::<_>::Ok(res.0)
         })??
     } else {
-        return Err(Error::index_header_validation_error("unknown header version").into());
+        return Err(ToolsError::index_header_validation_error("unknown header version").into());
     };
     for (_, headers) in headers {
         for header in headers {


### PR DESCRIPTION
Resolves #300 

Problem description: there are two `Error` definitions imported in `src/tools`: by `src/lib.rs/prelude` defined in `src/error.rs` and by `src/tools/mod.rs/prelude` defined in `src/tools/error.rs`. The easiest way (to not break anything) is to just rename the second one to `ToolsError`